### PR TITLE
Update ServiceExceptionUtil.java

### DIFF
--- a/common/common-framework/src/main/java/cn/iocoder/common/framework/util/ServiceExceptionUtil.java
+++ b/common/common-framework/src/main/java/cn/iocoder/common/framework/util/ServiceExceptionUtil.java
@@ -39,7 +39,7 @@ public class ServiceExceptionUtil {
         ServiceExceptionUtil.messages.put(code, message);
     }
 
-    // TODO 芋艿，可能不是目前最优解，目前暂时这样
+    // TODO 芋艿，可能不是目前最优解，目前暂时这样 枚举实现接口
     public static <T> CommonResult<T> error(Integer code) {
         return CommonResult.error(code, messages.get(code));
     }


### PR DESCRIPTION
自定义一个接口，声明方法getCode()，枚举实现这个接口并实现getCod()方法返回枚举实例的code，此处error方法的参数声明为该接口类型，然后error方法内部调用getCode方法获取code，这样，对于error方法来说，使用更安全了，避免传一个不存在的code，调用error方法的地方直接传枚举即可，省去大量枚举.getCode()调用，其他方法同，不知道我说清楚了么