### PR TITLE
Fix build

### DIFF
--- a/common/common-framework/pom.xml
+++ b/common/common-framework/pom.xml
@@ -59,7 +59,7 @@
 
         <!-- 工具相关 -->
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <optional>true</optional>
         </dependency>

--- a/mall-dependencies/pom.xml
+++ b/mall-dependencies/pom.xml
@@ -358,7 +358,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
             </dependency>

--- a/pay-service-project/pay-service-api/pom.xml
+++ b/pay-service-project/pay-service-api/pom.xml
@@ -21,5 +21,9 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>cn.iocoder.mall</groupId>
+            <artifactId>common-framework</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayChannelEnum.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayChannelEnum.java
@@ -1,0 +1,58 @@
+package cn.iocoder.mall.pay.api.constant;
+
+import cn.iocoder.common.framework.core.IntArrayValuable;
+
+import java.util.Arrays;
+
+/**
+ * 支付通道
+ */
+public enum PayChannelEnum implements IntArrayValuable {
+
+    WEIXIN_APP(100, "wx", "微信 App 支付"),
+    WEIXIN_PUB(101, "wxjs", "微信 JS API 支付"),
+
+    ALIPAY(200, "alipay", "支付宝 App 支付"),
+
+    PINGXX(9999, "ping++", "ping++ 支付"),
+    ;
+
+    public static final int[] ARRAYS = Arrays.stream(values()).mapToInt(PayChannelEnum::getId).toArray();
+
+    /**
+     * 渠道编号
+     */
+    private Integer id;
+    /**
+     * 编码
+     */
+    private String code;
+    /**
+     * 渠道名
+     */
+    private String name;
+
+    PayChannelEnum(Integer id, String code, String name) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int[] array() {
+        return ARRAYS;
+    }
+
+}

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayErrorCodeEnum.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayErrorCodeEnum.java
@@ -1,0 +1,46 @@
+package cn.iocoder.mall.pay.api.constant;
+
+/**
+ * 错误码枚举类
+ *
+ * 管理员系统，使用 1-004-000-000 段
+ */
+public enum PayErrorCodeEnum {
+
+    // ========== APP 模块 ==========
+    PAY_APP_NOT_FOUND(1004000000, "App 不存在"),
+    PAY_APP_IS_DISABLE(1004000001, "App 已经被禁用"),
+
+    // ========== TRANSACTION PAY 模块 ==========
+    PAY_TRANSACTION_NOT_FOUND(100401000, "支付交易单不存在"),
+    PAY_TRANSACTION_STATUS_IS_NOT_WAITING(100401001, "支付交易单不处于待支付"),
+    PAY_TRANSACTION_STATUS_IS_NOT_SUCCESS(100401002, "支付交易单不处于已支付"),
+    PAY_TRANSACTION_ERROR_USER(100401003, "支付交易单用户不正确"),
+
+    PAY_TRANSACTION_EXTENSION_NOT_FOUND(100401050, "支付交易拓展单不存在"),
+    PAY_TRANSACTION_EXTENSION_STATUS_IS_NOT_WAITING(100401051, "支付交易拓展单不处于待支付"),
+    PAY_TRANSACTION_EXTENSION_STATUS_IS_NOT_SUCCESS(100401052, "支付交易单不处于已支付"),
+
+    // ========== TRANSACTION REFUND 模块 ==========
+    PAY_REFUND_PRICE_EXCEED(100402000, "退款金额超过支付交易单可退金额"),
+    PAY_REFUND_NOT_FOUND(100402001, "退款单不存在"),
+    PAY_REFUND_STATUS_NOT_WAITING(100402002, "退款单不处于待处理"),
+    ;
+
+    private final int code;
+    private final String message;
+
+    PayErrorCodeEnum(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayNotifyType.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayNotifyType.java
@@ -1,0 +1,44 @@
+package cn.iocoder.mall.pay.api.constant;
+
+/**
+ * 支付通知类型
+ */
+public enum PayNotifyType {
+
+    TRANSACTION(1, "支付"),
+    REFUND(2, "退款"),
+    ;
+
+    /**
+     * 类型
+     */
+    private Integer value;
+    /**
+     * 名字
+     */
+    private String name;
+
+    PayNotifyType(Integer value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public PayNotifyType setValue(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PayNotifyType setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+}

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayRefundStatus.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayRefundStatus.java
@@ -1,0 +1,45 @@
+package cn.iocoder.mall.pay.api.constant;
+
+/**
+ * 支付退款状态枚举
+ */
+public enum PayRefundStatus {
+
+    WAITING(1, "处理中"),
+    SUCCESS(2, "成功"),
+    FAILURE(3, "失败"), // 例如说，支付单超时
+    ;
+
+    /**
+     * 状态
+     */
+    private Integer value;
+    /**
+     * 名字
+     */
+    private String name;
+
+    PayRefundStatus(Integer value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public PayRefundStatus setValue(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PayRefundStatus setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+}

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayTransactionNotifyStatusEnum.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayTransactionNotifyStatusEnum.java
@@ -1,0 +1,38 @@
+package cn.iocoder.mall.pay.api.constant;
+
+/**
+ * 支付交易通知状态枚举
+ */
+public enum PayTransactionNotifyStatusEnum {
+
+    WAITING(1, "等待通知"),
+    SUCCESS(2, "通知成功"),
+    FAILURE(3, "通知失败"), // 多次尝试，彻底失败
+    REQUEST_SUCCESS(4, "请求成功，但是结果失败"),
+    REQUEST_FAILURE(5, "请求失败"),
+
+    ;
+
+    /**
+     * 状态
+     */
+    private Integer value;
+    /**
+     * 名字
+     */
+    private String name;
+
+    PayTransactionNotifyStatusEnum(Integer value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayTransactionStatusEnum.java
+++ b/pay-service-project/pay-service-api/src/main/java/cn/iocoder/mall/pay/api/constant/PayTransactionStatusEnum.java
@@ -1,0 +1,45 @@
+package cn.iocoder.mall.pay.api.constant;
+
+/**
+ * 支付交易状态枚举
+ */
+public enum PayTransactionStatusEnum {
+
+    WAITING(1, "等待支付"),
+    SUCCESS(2, "支付成功"),
+    CANCEL(3, "取消支付"), // 例如说，支付单超时
+    ;
+
+    /**
+     * 状态
+     */
+    private Integer value;
+    /**
+     * 名字
+     */
+    private String name;
+
+    PayTransactionStatusEnum(Integer value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public PayTransactionStatusEnum setValue(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PayTransactionStatusEnum setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+}

--- a/pay-service-project/pay-service-app/pom.xml
+++ b/pay-service-project/pay-service-app/pom.xml
@@ -13,6 +13,12 @@
 
 
     <dependencies>
+        <!-- API 相关 -->
+        <dependency>
+            <artifactId>pay-service-api</artifactId>
+            <groupId>cn.iocoder.mall</groupId>
+        </dependency>
+
         <!-- RPC 相关 -->
         <dependency>
             <groupId>cn.iocoder.mall</groupId>

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/dal/mysql/mapper/transaction/TransactionMapper.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/dal/mysql/mapper/transaction/TransactionMapper.java
@@ -2,6 +2,7 @@ package cn.iocoder.mall.payservice.dal.mysql.mapper.transaction;
 
 import cn.iocoder.mall.mybatis.core.query.QueryWrapperX;
 import cn.iocoder.mall.payservice.dal.mysql.dataobject.transaction.TransactionDO;
+import cn.iocoder.mall.payservice.service.transaction.bo.TransactionPageBO;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/TransactionService.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/TransactionService.java
@@ -2,6 +2,7 @@ package cn.iocoder.mall.payservice.service.transaction;
 
 import cn.iocoder.common.framework.exception.util.ServiceExceptionUtil;
 import cn.iocoder.common.framework.vo.PageResult;
+import cn.iocoder.mall.pay.api.constant.PayErrorCodeEnum;
 import cn.iocoder.mall.payservice.convert.transaction.TransactionConvert;
 import cn.iocoder.mall.payservice.dal.mysql.dataobject.transaction.TransactionDO;
 import cn.iocoder.mall.payservice.dal.mysql.mapper.transaction.TransactionMapper;
@@ -50,7 +51,7 @@ public class TransactionService {
     public void updateTransaction(@Valid TransactionUpdateBO updateBO) {
         // 校验更新的pay_transaction是否存在
         if (transactionMapper.selectById(updateBO.getId()) == null) {
-            throw ServiceExceptionUtil.exception(AuthErrorCodeConstants.TRANSACTION_NOT_FOUND);
+            throw ServiceExceptionUtil.exception(PayErrorCodeEnum.PAY_TRANSACTION_NOT_FOUND.getCode());
         }
         // 更新到数据库
         TransactionDO updateObject = TransactionConvert.INSTANCE.convert(updateBO);
@@ -65,7 +66,7 @@ public class TransactionService {
     public void deleteTransaction(Integer transactionId) {
         // 校验删除的pay_transaction是否存在
         if (transactionMapper.selectById(transactionId) == null) {
-            throw ServiceExceptionHelper.exception(AuthErrorCodeConstants.TRANSACTION_NOT_FOUND);
+            throw ServiceExceptionUtil.exception(PayErrorCodeEnum.PAY_TRANSACTION_NOT_FOUND.getCode());
         }
         // 标记删除
         transactionMapper.deleteById(transactionId);

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionBO.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionBO.java
@@ -2,7 +2,6 @@ package cn.iocoder.mall.payservice.service.transaction.bo;
 
 import lombok.*;
 import lombok.experimental.*;
-import io.swagger.annotations.*;
 import java.util.*;
 
 /**

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionCreateBO.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionCreateBO.java
@@ -2,7 +2,6 @@ package cn.iocoder.mall.payservice.service.transaction.bo;
 
 import lombok.*;
 import lombok.experimental.*;
-import io.swagger.annotations.*;
 import java.util.*;
 import javax.validation.constraints.*;
 

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionPageBO.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionPageBO.java
@@ -1,11 +1,11 @@
 package cn.iocoder.mall.payservice.service.transaction.bo;
 
 import cn.iocoder.common.framework.vo.PageParam;
-import lombok.*;
-import lombok.experimental.*;
-import io.swagger.annotations.*;
-import java.util.*;
-import javax.validation.constraints.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+import java.util.Date;
 
 /**
 * pay_transaction分页 BO

--- a/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionUpdateBO.java
+++ b/pay-service-project/pay-service-app/src/main/java/cn/iocoder/mall/payservice/service/transaction/bo/TransactionUpdateBO.java
@@ -2,7 +2,6 @@ package cn.iocoder.mall.payservice.service.transaction.bo;
 
 import lombok.*;
 import lombok.experimental.*;
-import io.swagger.annotations.*;
 import java.util.*;
 import javax.validation.constraints.*;
 

--- a/pay-service-project/pom.xml
+++ b/pay-service-project/pom.xml
@@ -35,6 +35,13 @@
                 <version>1.0-SNAPSHOT</version>
             </dependency>
 
+            <!-- API 相关 -->
+            <dependency>
+                <artifactId>pay-service-api</artifactId>
+                <groupId>cn.iocoder.mall</groupId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/promotion-service-project/promotion-service-api/pom.xml
+++ b/promotion-service-project/promotion-service-api/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <optional>true</optional>
         </dependency>

--- a/system-service-project/system-service-api/pom.xml
+++ b/system-service-project/system-service-api/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
 


### PR DESCRIPTION
fixes [https://github.com/YunaiV/onemall/issues/38](https://github.com/YunaiV/onemall/issues/38)、 [https://github.com/YunaiV/onemall/issues/30](https://github.com/YunaiV/onemall/issues/30)
修复目前项目无法编译通过的一些问题 
主要做以下修改：
1、hibernate-validator已经迁移到`org.hibernate.validator` 原来的maven配置是下载不了包的  [查看详情](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator/6.0.16.Final)
2、TransactionService类编译报错，注意到目前应该在重构包名迁移，但是api包还没搬过来，我这边先把原来api包的静态枚举类移过来了
3、一些没用的引用包没有删除导致编译不通过 如：swagger的api包

@YunaiV 可以帮忙看下以上修改是否合理？顺便问下能否给出重构的计划，我这边也有兴趣参与下 . Thanks.